### PR TITLE
feat: vision-sim（視界体験）のプライバシーポリシーを追加

### DIFF
--- a/docs/PraivacyPolicy/vision_sim/jp.html
+++ b/docs/PraivacyPolicy/vision_sim/jp.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>プライバシーポリシー - 視界体験</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        h1 {
+            font-size: 2em;
+            margin-bottom: 1em;
+            color: #2c3e50;
+        }
+        h2 {
+            font-size: 1.5em;
+            margin-top: 1.5em;
+            color: #34495e;
+        }
+        h3 {
+            font-size: 1.2em;
+            color: #7f8c8d;
+        }
+        ul {
+            padding-left: 20px;
+        }
+        li {
+            margin-bottom: 0.5em;
+        }
+        a {
+            color: #3498db;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        .notice {
+            background-color: #f8f9fa;
+            border-left: 4px solid #3498db;
+            padding: 12px 16px;
+            margin: 1em 0;
+        }
+        .footer {
+            margin-top: 2em;
+            padding-top: 1em;
+            border-top: 1px solid #eee;
+            font-size: 0.9em;
+            color: #7f8c8d;
+        }
+    </style>
+</head>
+<body>
+    <h1>プライバシーポリシー</h1>
+
+    <h2>1. はじめに</h2>
+    <p>視界体験（以下「本アプリ」）は、Kyohei Takeshita（以下「サービス提供者」）によって提供される、視覚障害の見え方を体験することで理解を促進する教育ツールです。本アプリのご利用に際して、ユーザーのプライバシー保護を最優先に考え、以下のポリシーに基づき運用します。</p>
+
+    <div class="notice">
+        <strong>本アプリの基本方針：</strong>
+        <ul style="margin-bottom: 0;">
+            <li>個人情報を一切収集しません</li>
+            <li>カメラ映像は端末内でのみ処理され、外部サーバーに送信されません</li>
+            <li>アカウント登録やログインは不要です</li>
+            <li>広告・課金・解析ツールは使用していません</li>
+        </ul>
+    </div>
+
+    <h2>2. 収集する情報</h2>
+    <p>本アプリは、ユーザーの個人情報を一切収集しません。</p>
+
+    <h2>3. カメラ映像の取り扱い</h2>
+    <p>本アプリはシミュレーション機能のためにデバイスのカメラにアクセスしますが、カメラ映像は以下の通り取り扱われます。</p>
+    <ul>
+        <li>カメラ映像は<strong>端末内でリアルタイムに処理</strong>されます</li>
+        <li>カメラ映像を<strong>外部サーバーに送信することは一切ありません</strong></li>
+        <li>カメラ映像を<strong>保存することはありません</strong>（ユーザーがシャッターボタンで撮影した場合のみ、ユーザーのフォトライブラリに保存されます）</li>
+    </ul>
+
+    <h2>4. 撮影画像の取り扱い</h2>
+    <p>ユーザーがアプリ内のシャッターボタンで撮影したシミュレーション画像は、ユーザーの端末のフォトライブラリに保存されます。</p>
+    <ul>
+        <li>保存された画像はユーザー自身の管理下にあります</li>
+        <li>本アプリが撮影画像を外部に送信することはありません</li>
+        <li>ユーザーがSNSシェア機能を使用する場合は、OS標準のシェア機能を経由してユーザー自身が選択したアプリに送信されます。この場合、送信先アプリのプライバシーポリシーが適用されます</li>
+    </ul>
+
+    <h2>5. パーミッション（アクセス許可）</h2>
+    <p>本アプリは以下のパーミッションを要求します。これらのパーミッションは、該当機能を使用する場合のみに利用されます。</p>
+    <ul>
+        <li><strong>カメラ</strong>：視覚障害シミュレーションのリアルタイム表示</li>
+        <li><strong>フォトライブラリ（写真の追加）</strong>：撮影したシミュレーション画像の保存</li>
+    </ul>
+
+    <h2>6. 端末内に保存される設定データ</h2>
+    <p>本アプリは、ユーザーの利便性向上のため、以下の設定データを端末内のみに保存します（外部送信なし）。</p>
+    <ul>
+        <li>オンボーディング完了フラグ</li>
+        <li>選択した疾患タイプ</li>
+        <li>各疾患のシミュレーションパラメータ設定</li>
+        <li>前面カメラ使用設定、ウォーターマーク設定 等</li>
+    </ul>
+    <p>これらのデータはアプリをアンインストールすると削除されます。</p>
+
+    <h2>7. 第三者への提供</h2>
+    <p>本アプリは、ユーザーの情報を第三者に提供することはありません。</p>
+
+    <h2>8. アクセス解析ツール</h2>
+    <p>本アプリは現時点でアクセス解析ツールを使用していません。</p>
+    <p>将来的にFirebase Analytics等を導入する場合は、本ポリシーを更新し、利用開始前にユーザーに通知します。</p>
+
+    <h2>9. 外部リンク</h2>
+    <p>本アプリには、以下の外部サービスへのリンクが含まれる場合があります。これらの外部サービスのプライバシーポリシーは各サービスのものが適用されます。</p>
+    <ul>
+        <li>JRPS（日本網膜色素変性症協会）</li>
+        <li>日本眼科医会</li>
+        <li>note（開発者の記事）</li>
+        <li>Buy Me a Coffee（開発者支援）</li>
+    </ul>
+
+    <h2>10. 免責事項</h2>
+    <ul>
+        <li>本アプリは<strong>医療機器ではありません</strong>。診断や治療を目的としたものではなく、視覚障害の理解促進を目的とした教育ツールです</li>
+        <li>シミュレーションは実際の見え方の完全な再現ではありません。視覚障害の症状には個人差があります</li>
+        <li>本アプリの使用によって生じた一切の損害について、開発者は責任を負いません</li>
+    </ul>
+
+    <h2>11. ユーザーの権利</h2>
+    <p>本アプリは個人情報を収集しませんが、以下の権利を保障します。</p>
+    <ul>
+        <li>アプリをアンインストールすることで、端末内の設定データを全て削除できます</li>
+        <li>フォトライブラリに保存された撮影画像は、ユーザー自身の操作で削除可能です</li>
+    </ul>
+
+    <h2>12. ポリシーの変更</h2>
+    <p>本プライバシーポリシーは、必要に応じて変更されることがあります。重要な変更があった場合は、アプリ内または本ページにて通知します。</p>
+
+    <h2>13. お問い合わせ</h2>
+    <p>本ポリシーに関するお問い合わせは、<a href="mailto:support+vision_sim@oh-yeah-sea-kit2.com">support+vision_sim@oh-yeah-sea-kit2.com</a>までご連絡ください。</p>
+
+    <div class="footer">
+        <p>最終更新日：2026年4月17日</p>
+        <p>お問い合わせ：<a href="mailto:support+vision_sim@oh-yeah-sea-kit2.com">support+vision_sim@oh-yeah-sea-kit2.com</a></p>
+    </div>
+</body>
+</html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,3 +3,4 @@
 - [https://oh-yeah-sea-kit2.github.io/PraivacyPolicy/jin-journey/en](https://oh-yeah-sea-kit2.github.io/PraivacyPolicy/jin-journey/en)
 - [https://oh-yeah-sea-kit2.github.io/PraivacyPolicy/chatgpt-notifier/jp](https://oh-yeah-sea-kit2.github.io/PraivacyPolicy/chatgpt-notifier/jp)
 - [https://oh-yeah-sea-kit2.github.io/PraivacyPolicy/my_cheki_collection/jp](https://oh-yeah-sea-kit2.github.io/PraivacyPolicy/my_cheki_collection/jp)
+- [https://oh-yeah-sea-kit2.github.io/PraivacyPolicy/vision_sim/jp](https://oh-yeah-sea-kit2.github.io/PraivacyPolicy/vision_sim/jp)


### PR DESCRIPTION
## Summary
- 視覚障害シミュレーターアプリ「視界体験」のプライバシーポリシーを既存の `my_cheki_collection` テンプレートに沿って追加
- 本アプリは個人情報を収集せず、カメラ映像は端末内処理のみ、アカウント機能なし、広告・課金・解析なし
- `docs/PraivacyPolicy/vision_sim/jp.html` を作成
- `docs/index.md` に公開URLのリンクを追加

## 公開URL（マージ後）
https://oh-yeah-sea-kit2.github.io/PraivacyPolicy/vision_sim/jp

## Test plan
- [ ] GitHub Pages でHTMLが正しくレンダリングされることを確認
- [ ] 公開URL をApp Store Connect / Google Play Console のプライバシーポリシーURL欄に設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)