### PR TITLE
お問い合わせメールを info+{app}@oysk2.com に統一

### DIFF
--- a/docs/PraivacyPolicy/jin-journey/en.html
+++ b/docs/PraivacyPolicy/jin-journey/en.html
@@ -151,7 +151,7 @@
     <p><strong>Contact Us</strong></p>
     <p>
       If you have any questions or suggestions about my Privacy Policy, do not
-      hesitate to contact me at kyohei@oh-yeah-sea-kit2.com.
+      hesitate to contact me at info+jin_journey@oysk2.com.
     </p>
     <p>
       This privacy policy page was created at

--- a/docs/PraivacyPolicy/my_cheki_collection/jp.html
+++ b/docs/PraivacyPolicy/my_cheki_collection/jp.html
@@ -126,11 +126,11 @@
         <li>個人情報の削除</li>
         <li>同意の撤回</li>
     </ul>
-    <p>これらの権利を行使する場合は、<a href="mailto:support+chekikore_app@oh-yeah-sea-kit2.com">support+chekikore_app@oh-yeah-sea-kit2.com</a>までご連絡ください。</p>
+    <p>これらの権利を行使する場合は、<a href="mailto:info+chekikore_app@oysk2.com">info+chekikore_app@oysk2.com</a>までご連絡ください。</p>
 
     <div class="footer">
         <p>最終更新日：2024年1月23日</p>
-        <p>お問い合わせ：<a href="mailto:support+chekikore_app@oh-yeah-sea-kit2.com">support+chekikore_app@oh-yeah-sea-kit2.com</a></p>
+        <p>お問い合わせ：<a href="mailto:info+chekikore_app@oysk2.com">info+chekikore_app@oysk2.com</a></p>
         <p>X（Twitter）：<a href="https://twitter.com/chekikore_app">@chekikore_app</a></p>
     </div>
 </body>

--- a/docs/PraivacyPolicy/vision_sim/en.html
+++ b/docs/PraivacyPolicy/vision_sim/en.html
@@ -144,11 +144,11 @@
     <p>This Privacy Policy may be updated as needed. If significant changes are made, we will notify users in the App or on this page.</p>
 
     <h2>13. Contact</h2>
-    <p>For questions about this policy, please contact <a href="mailto:support+vision_sim@oh-yeah-sea-kit2.com">support+vision_sim@oh-yeah-sea-kit2.com</a>.</p>
+    <p>For questions about this policy, please contact <a href="mailto:info+vision_sim@oysk2.com">info+vision_sim@oysk2.com</a>.</p>
 
     <div class="footer">
         <p>Last updated: April 17, 2026</p>
-        <p>Contact: <a href="mailto:support+vision_sim@oh-yeah-sea-kit2.com">support+vision_sim@oh-yeah-sea-kit2.com</a></p>
+        <p>Contact: <a href="mailto:info+vision_sim@oysk2.com">info+vision_sim@oysk2.com</a></p>
     </div>
 </body>
 </html>

--- a/docs/PraivacyPolicy/vision_sim/jp.html
+++ b/docs/PraivacyPolicy/vision_sim/jp.html
@@ -144,11 +144,11 @@
     <p>本プライバシーポリシーは、必要に応じて変更されることがあります。重要な変更があった場合は、アプリ内または本ページにて通知します。</p>
 
     <h2>13. お問い合わせ</h2>
-    <p>本ポリシーに関するお問い合わせは、<a href="mailto:support+vision_sim@oh-yeah-sea-kit2.com">support+vision_sim@oh-yeah-sea-kit2.com</a>までご連絡ください。</p>
+    <p>本ポリシーに関するお問い合わせは、<a href="mailto:info+vision_sim@oysk2.com">info+vision_sim@oysk2.com</a>までご連絡ください。</p>
 
     <div class="footer">
         <p>最終更新日：2026年4月17日</p>
-        <p>お問い合わせ：<a href="mailto:support+vision_sim@oh-yeah-sea-kit2.com">support+vision_sim@oh-yeah-sea-kit2.com</a></p>
+        <p>お問い合わせ：<a href="mailto:info+vision_sim@oysk2.com">info+vision_sim@oysk2.com</a></p>
     </div>
 </body>
 </html>

--- a/docs/PraivacyPolicy/walking_bingo/en.html
+++ b/docs/PraivacyPolicy/walking_bingo/en.html
@@ -151,7 +151,7 @@
     <p><strong>Contact Us</strong></p>
     <p>
       If you have any questions or suggestions about my Privacy Policy, do not
-      hesitate to contact me at kyohei@oh-yeah-sea-kit2.com.
+      hesitate to contact me at info+walking_bingo@oysk2.com.
     </p>
     <p>
       This privacy policy page was created at


### PR DESCRIPTION
## Summary
`support` アカウント廃止に伴い、全プライバシーポリシーの問い合わせ先メールアドレスを新しい短縮ドメイン `oysk2.com` の `info+` エイリアス形式に統一。

## 変更内容
| ファイル | 変更前 → 変更後 |
|---|---|
| `vision_sim/jp.html` | `support+vision_sim@oh-yeah-sea-kit2.com` → `info+vision_sim@oysk2.com` (×2) |
| `vision_sim/en.html` | 同上 (×2) |
| `my_cheki_collection/jp.html` | `support+chekikore_app@oh-yeah-sea-kit2.com` → `info+chekikore_app@oysk2.com` (×2) |
| `jin-journey/en.html` | `kyohei@oh-yeah-sea-kit2.com` → `info+jin_journey@oysk2.com` (×1) |
| `walking_bingo/en.html` | `kyohei@oh-yeah-sea-kit2.com` → `info+walking_bingo@oysk2.com` (×1) |

`oysk2.com` は `oh-yeah-sea-kit2.com` の短縮ドメイン。`chatgpt-notifier` はメールアドレス記載がないため対象外。

## Test plan
- [ ] GitHub Pages で各ページのメールアドレスが正しく表示されることを確認
- [ ] mailto リンクから新アドレスでメーラーが起動することを確認
- [ ] `info+vision_sim@oysk2.com` 等のエイリアスが実際に受信できるかテスト送信

🤖 Generated with [Claude Code](https://claude.com/claude-code)